### PR TITLE
Add FoxyBridge functionality to replace 'Add to Chrome' button

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,33 @@
+(function() {
+  // Function to detect the "Add to Chrome" button and replace it with "Add to Firefox"
+  function replaceAddToChromeButton() {
+    const addToChromeButton = document.querySelector('.webstore-test-button-label');
+    if (addToChromeButton) {
+      const addToFirefoxButton = document.createElement('button');
+      addToFirefoxButton.textContent = 'Add to Firefox';
+      addToFirefoxButton.style.backgroundColor = '#4a90e2';
+      addToFirefoxButton.style.color = '#fff';
+      addToFirefoxButton.style.border = 'none';
+      addToFirefoxButton.style.padding = '10px 20px';
+      addToFirefoxButton.style.cursor = 'pointer';
+      addToFirefoxButton.addEventListener('click', downloadExtensionAsZip);
+      addToChromeButton.parentNode.replaceChild(addToFirefoxButton, addToChromeButton);
+    }
+  }
+
+  // Function to trigger FoxyBridge’s download function
+  function downloadExtensionAsZip() {
+    // Assuming FoxyBridge has a function called downloadAsZip
+    if (typeof FoxyBridge !== 'undefined' && typeof FoxyBridge.downloadAsZip === 'function') {
+      FoxyBridge.downloadAsZip();
+    } else {
+      console.error('FoxyBridge download function not found.');
+    }
+  }
+
+  // Export the function to be used in the content script
+  window.replaceAddToChromeButton = replaceAddToChromeButton;
+
+  // Run the function to replace the button
+  replaceAddToChromeButton();
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -59,5 +59,16 @@
         "webRequest",
         "webRequestBlocking",
         "*://*/*"
+    ],
+    "content_scripts": [
+        {
+            "matches": [
+                "*://chrome.google.com/webstore/detail/*",
+                "*://chromewebstore.google.com/detail/*"
+            ],
+            "js": [
+                "content.js"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
Add functionality to replace "Add to Chrome" button with "Add to Firefox" button and trigger FoxyBridge’s download function.

* **src/content.js**: Add a function to detect and replace the "Add to Chrome" button with "Add to Firefox". Add an event listener to the new button to trigger FoxyBridge’s download function. Export the function to be used in the content script.
* **src/manifest.json**: Add the new content script `src/content.js` to the `content_scripts` section. Add necessary permissions for the content script to run on the Chrome Web Store.

